### PR TITLE
Implement dry-runs

### DIFF
--- a/bin/cloudat
+++ b/bin/cloudat
@@ -1,15 +1,6 @@
 #!/usr/bin/env ruby
 # vim: set filetype=ruby:
 
-require 'cloudat'
-require 'cloudat/dsl'
+require 'cloudat/cli'
 
-if ARGV.length > 0
-  config = Cloudat::Configuration.new
-  plan_file = ARGV[0]
-  plan_content = File.read(plan_file)
-  plan = Cloudat::Dsl::Plan.new(config)
-  plan.instance_eval(plan_content, plan_file)
-else
-  puts 'Usage: bundle exec cloudat plan_file.rb'
-end
+Cloudat::Cli.start

--- a/cloudat.gemspec
+++ b/cloudat.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
 
+  spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'rufus-scheduler', '~> 3.1'
 end

--- a/lib/cloudat/cli.rb
+++ b/lib/cloudat/cli.rb
@@ -5,17 +5,17 @@ require 'cloudat/dsl'
 module Cloudat
   # Command line Interface
   class Cli < Thor
-    class_option 'dry-run',
-                 type: :boolean,
-                 desc: 'List all actions that would be executed, but doesn\'t'\
-                       ' actually do anything',
-                 default: false
+    method_option 'dry-run',
+                  type: :boolean,
+                  desc: 'List all actions that would be executed, but doesn\'t'\
+                        ' actually do anything',
+                  default: false
 
-    class_option 'plan',
-                 type: :string,
-                 desc: 'Path to the plan to execute',
-                 default: nil,
-                 required: true
+    method_option 'plan',
+                  type: :string,
+                  desc: 'Path to the plan to execute',
+                  default: nil,
+                  required: true
 
     desc 'exec', 'Executes the tasks described in the plan'
     def exec
@@ -26,5 +26,7 @@ module Cloudat
       plan = Cloudat::Dsl::Plan.new(config)
       plan.instance_eval(plan_content, plan_file)
     end
+
+    default_task :exec
   end
 end

--- a/lib/cloudat/cli.rb
+++ b/lib/cloudat/cli.rb
@@ -1,0 +1,30 @@
+require 'thor'
+require 'cloudat'
+require 'cloudat/dsl'
+
+module Cloudat
+  # Command line Interface
+  class Cli < Thor
+    class_option 'dry-run',
+                 type: :boolean,
+                 desc: 'List all actions that would be executed, but doesn\'t'\
+                       ' actually do anything',
+                 default: false
+
+    class_option 'plan',
+                 type: :string,
+                 desc: 'Path to the plan to execute',
+                 default: nil,
+                 required: true
+
+    desc 'exec', 'Executes the tasks described in the plan'
+    def exec
+      config = Cloudat::Configuration.new(options)
+      plan_file = options['plan']
+
+      plan_content = File.read(plan_file)
+      plan = Cloudat::Dsl::Plan.new(config)
+      plan.instance_eval(plan_content, plan_file)
+    end
+  end
+end

--- a/lib/cloudat/configuration.rb
+++ b/lib/cloudat/configuration.rb
@@ -1,5 +1,13 @@
 module Cloudat
   class Configuration
+    def initialize(options = {})
+      @options = options
+    end
+
+    def options(option)
+      @options[option.to_s]
+    end
+
     def init_logger(*args)
       args << STDOUT if args.empty?
       logger = ::Logger.new(*args)

--- a/lib/cloudat/dsl/plan.rb
+++ b/lib/cloudat/dsl/plan.rb
@@ -5,7 +5,7 @@ module Cloudat
       include Cloudat::Dsl::Schedule
 
       def initialize(cfg = nil)
-        config = cfg
+        @config = cfg
         init_dsl
       end
 
@@ -75,10 +75,23 @@ module Cloudat
         init_dsl
       end
 
-      def send_action_method(action, *args, &_block)
-        logger.debug("Sending action: #{action}")
-        args.each do |arg|
-          arg.send(action)
+      def dry_run?
+        config.options('dry-run')
+      end
+
+      def send_action_method(action, resources)
+        logger.debug("Sending action: #{action} on #{resources.inspect}")
+
+        Array(resources).each do |resource|
+          # Stop here if we're in dry-run
+          logger.info("Would have executed #{action} on #{resource}") if dry_run?
+          next if dry_run?
+
+          if resource.is_a?(Array)
+            resource.each(&action)
+          else
+            resource.send(action)
+          end
         end
       end
     end

--- a/lib/cloudat/dsl/plan.rb
+++ b/lib/cloudat/dsl/plan.rb
@@ -78,11 +78,7 @@ module Cloudat
       def send_action_method(action, *args, &_block)
         logger.debug("Sending action: #{action}")
         args.each do |arg|
-          if arg.is_a?(Array)
-            arg.each(&action)
-          else
-            arg.send(action)
-          end
+          arg.send(action)
         end
       end
     end


### PR DESCRIPTION
Add the possibility to pass a --dry-run option to only print what would be executed
The CLI has been reimplemented using thor and **is not backwards-compatible**

New syntax:
```
cloudat exec --plan <plan file> [--dry-run]
```